### PR TITLE
NativeAOT wasm compilation

### DIFF
--- a/wordcount/count/count.csproj
+++ b/wordcount/count/count.csproj
@@ -9,8 +9,13 @@
     <RuntimeIdentifier>wasi-wasm</RuntimeIdentifier>
     <WasmSingleFileBundle>true</WasmSingleFileBundle>
     <!-- <PublishAot>true</PublishAot>
-    <OptimizationPreference>Speed</OptimizationPreference>
-    <InvariantGlobalization>true</InvariantGlobalization> -->
+    <OptimizationPreference>Speed</OptimizationPreference> -->
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
+
+  <ItemGroup>
+      <PackageReference Include="WasmComponent.Sdk" Version="0.1.0-preview00026" />
+  </ItemGroup>
 
 </Project>

--- a/wordcount/count/nuget.config
+++ b/wordcount/count/nuget.config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+		<add key="dotnet-experimental" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Uses the NativeAOT-LLVM compilation mechanism via my experimental `WasmComponent.Sdk` package. Hopefully the NuGet restore will work correctly but I haven't tried it on a clean machine yet.

**WARNING**: NativeAOT-LLVM compilation is only supported on Windows right now, due to limitations in the underlying compilation tooling. I believe this is being worked on. However, once you've built a `.wasm` file, you can move it to any other OS and run it there.

Usage:

 * `cd wordcount\count\`
 * `dotnet build -c Release`
 * `cd ..`
 * `wasmtime run --dir . count\bin\Release\net8.0\wasi-wasm\native\count.wasm Clarissa_Harlowe`

Note that you want to run `count.wasm`, not `count.component.wasm` which is also generated but is for a different use case.